### PR TITLE
Create meta issue template for moderation requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/meta.yaml
+++ b/.github/ISSUE_TEMPLATE/meta.yaml
@@ -1,0 +1,46 @@
+name: Meta Issue (Moderation / Policy Action)
+description: Use this ONLY for specific meta actions such as moderation policy changes or ban/unban requests
+title: "[META] <short description>"
+labels:
+  - meta
+assignees: []
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Purpose
+
+        This repository is for **specific, actionable meta issues only**, such as:
+        - Proposing or modifying moderation policies
+        - Requesting a user to be banned or unbanned
+
+        It is **not** for general discussion, brainstorming, or open-ended questions.
+
+        All other topics should be posted in **GitHub Discussions**:
+        https://github.com/bitcoin-core/meta/discussions
+
+  - type: checkboxes
+    id: type
+    attributes:
+      label: Type of Request
+      description: Select one
+      options:
+        - label: Moderation policy change
+        - label: Ban request
+        - label: Unban request
+    validations:
+      required: true
+
+  - type: textarea
+    id: details
+    attributes:
+      label: Details
+      description: |
+        Provide all relevant context, justification, and links.
+
+        - For policy changes: explain the current issue and the proposed change
+        - For ban/unban requests: include history, evidence, and rationale
+      placeholder: Enter full details here
+    validations:
+      required: true


### PR DESCRIPTION
Related to https://github.com/bitcoin-core/meta/issues/29#issuecomment-4122641597
I'm thinking we specify that issues in this repo must have a specific goal in mind like changing moderation policy or (un)banning a user. Everything else should be redirected to discussions, which are open-ended forever and multi threaded.

Try it out on my fork: https://github.com/pinheadmz/bitcoin-core-meta/issues